### PR TITLE
Variable blacklist css

### DIFF
--- a/public/supafakeblock.css
+++ b/public/supafakeblock.css
@@ -1,4 +1,33 @@
 .sfb_blacklisted {
-    background-color: rgb(255,0,0) !important;
     display: inherit !important;
 }
+
+.sfb_SCAMMER {
+    background-color: red !important;
+}
+
+.sfb_SPAMMER {
+    background-color: orange !important;
+}
+
+.sfb_FAKE_PROFILE {
+    background-color: yellow !important;
+}
+
+.sfb_blacklisted_not_sure {
+    opacity: 25%;
+}
+
+.sfb_blacklisted_meh {
+    opacity: 50%;
+}
+
+.sfb_blacklisted_probably {
+    opacity: 75%;
+}
+
+.sfb_blacklisted_absolutely {
+    opacity: 100%;
+}
+
+/* TODO: .sfb_UNKNOWN ? */

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,7 +1,7 @@
 // TODO: rename to "facebook.ts"?
 
 import { createTheme } from "@mantine/core";
-import { Command } from "./types";
+import { Command, ReportStats } from "./types";
 
 export const theme = createTheme({
     primaryColor: 'red'
@@ -81,7 +81,7 @@ export function updateProfileLinks(): void {
         // validate URLs, e.g. skipping profile links with additional "search params"
         if(profileId) {
             markAsEvaluated(profileLink);
-            isBlacklisted(profileId, () => blacklistProfileLink(profileLink));
+            isBlacklisted(profileId, profileLink, blacklistProfileLink);
         }
     });
 }
@@ -90,19 +90,30 @@ export function markAsEvaluated(e: Element) {
     e.classList.add('sfb_evaluated');
 }
 
-function isBlacklisted(profileId: number, performIfBlacklisted: Function): void {
+function isBlacklisted(profileId: number, profileLink: HTMLAnchorElement, performIfBlacklisted: (profileLink: HTMLAnchorElement, reportStats: ReportStats) => void): void {
     chrome.runtime.sendMessage({
             command: Command.IsBlacklisted,
             body: profileId,
         },
-        (isInBlacklist: boolean) => {
-            if(isInBlacklist) performIfBlacklisted()
+        (reportStats: ReportStats) => {
+            if(reportStats) {
+                performIfBlacklisted(profileLink, reportStats);
+            }
         }
     );
 }
 
-export function blacklistProfileLink(profileLink: HTMLAnchorElement): void {
-    profileLink.classList.add('sfb_blacklisted');
+export function blacklistProfileLink(profileLink: HTMLAnchorElement, reportStats: ReportStats): void {
+    console.log(`blacklistProfileLink: `, reportStats);
+    profileLink.classList.add('sfb_blacklisted', `sfb_${reportStats.type}`, `sfb_blacklisted_${confidenceToString(parseFloat(reportStats.avgConfidence))}`);
+}
+
+function confidenceToString(confidence: number): string {
+    if(confidence <= 0.75) return 'not_sure';
+    if(confidence <= 0.50) return 'meh';
+    if(confidence <= 0.25) return 'probably';
+
+    return 'absolutely;'
 }
 
 /**

--- a/src/common.ts
+++ b/src/common.ts
@@ -104,7 +104,6 @@ export function isBlacklisted(profileId: number, profileLink: HTMLAnchorElement,
 }
 
 export function blacklistProfileLink(profileLink: HTMLAnchorElement, reportStats: ReportStats): void {
-    console.log(`blacklistProfileLink: `, reportStats);
     profileLink.classList.add('sfb_blacklisted', `sfb_${reportStats.type}`, `sfb_blacklisted_${confidenceToString(parseFloat(reportStats.avgConfidence))}`);
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -90,7 +90,7 @@ export function markAsEvaluated(e: Element) {
     e.classList.add('sfb_evaluated');
 }
 
-function isBlacklisted(profileId: number, profileLink: HTMLAnchorElement, performIfBlacklisted: (profileLink: HTMLAnchorElement, reportStats: ReportStats) => void): void {
+export function isBlacklisted(profileId: number, profileLink: HTMLAnchorElement, performIfBlacklisted: (profileLink: HTMLAnchorElement, reportStats: ReportStats) => void): void {
     chrome.runtime.sendMessage({
             command: Command.IsBlacklisted,
             body: profileId,

--- a/src/detection.ts
+++ b/src/detection.ts
@@ -1,4 +1,5 @@
 import { NotificationData, notifications } from '@mantine/notifications';
+import { isBlacklisted, profileIdFromUrl } from './common';
 
 const CLONED_NICKNAME_REGEX = /^https:\/\/www.facebook.com\/.*\d+.*\D+\/$/;
 const PRONOUN_REGEX = /updated (.*) profile picture/;
@@ -10,6 +11,8 @@ export function detection() {
     checkForClonedNickname();
     checkForAngryReactions();
     checkForBackdatedPosts();
+
+    engagement();
 }
 
 function checkForClonedNickname(): void {
@@ -61,6 +64,76 @@ function checkForBackdatedPosts(): void {
 
         return true;
     });
+}
+
+function engagement(): void {
+    const profileName = getProfileName();
+
+    const reactionSet = new Set();
+
+    let selfReaction = false;
+    let blacklistedReaction = false;
+
+    Array.from(document.querySelectorAll('div[data-visualcompletion="ignore-dynamic"] span[aria-label="See who reacted to this"]')).some((e: Element) => {
+
+        if(selfReaction) {
+            return true;
+        }
+
+        // @ts-ignore
+        const reactionButton = e.nextSibling?.querySelector('div[role="button"]');
+
+        if(reactionButton) {
+            reactionButton.click();
+        }
+
+        // TODO: This needs to be ported to a mutation observer and get rid of setTimeout
+        setTimeout(() => {
+            const reactions = document.querySelectorAll('div[data-visualcompletion="ignore-dynamic"] span[dir="auto"] a[role="link"]');
+            reactions.forEach((e) => {
+                reactionSet.add(e.textContent);
+
+                if(blacklistedReaction) {
+                    return;
+                }
+
+                const profileLink = e as HTMLAnchorElement;
+
+                const profileId = profileIdFromUrl(profileLink.href);
+                if(profileId) {
+                    isBlacklisted(profileId, profileLink, () => {
+                        showNotification({
+                            title: 'Blacklisted Engagement',
+                            message: '🤬 Blacklisted Profile Engagement Detected',
+                            color: 'red'
+                        });
+
+                        blacklistedReaction = true;
+                    });
+                }
+            });
+
+            // @ts-ignore
+            const close = document.querySelector('div[aria-label="Close"]')?.click();
+
+            if(reactionSet.has(profileName)) {
+                if(!selfReaction) {
+                    showNotification({
+                        title: 'Self Engagement',
+                        message: '🤡 Self Engagement Detected',
+                        color: 'red'
+                    });
+                }
+
+                selfReaction = true;
+            }
+        }, 500);
+    });
+}
+
+function getProfileName(): string {
+    // TODO: null safety
+    return document.querySelector('div[data-visualcompletion="ignore-dynamic"] a[role="link"]')!.textContent!
 }
 
 function showNotification(notification: NotificationData): void {

--- a/src/report_modal.tsx
+++ b/src/report_modal.tsx
@@ -27,7 +27,10 @@ export function ReportModal(props: ReportModalProps) {
         });
 
         // Render blacklisted group profile links
-        queryProfileLinks((e) => blacklistProfileLink(e as HTMLAnchorElement), props.profileId);
+        queryProfileLinks((e) => blacklistProfileLink(e as HTMLAnchorElement, {
+            type: reportType,
+            avgConfidence: confidence,
+        }), props.profileId);
 
         setNotes('');
         props.close();

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export enum ReportType {
     SCAMMER = 'SCAMMER',
     SPAMMER = 'SPAMMER',
     FAKE_PROFILE = 'FAKE_PROFILE',
+    UNKNOWN = 'UNKNOWN'
 }
 
 export enum ReportConfidence {
@@ -28,9 +29,11 @@ export interface PromptRequest {
     avgConfidence: number
 }
 
+// TODO: number/string types, and this is getting overload, e.g. optionakl up/down votes
 export interface ReportStats {
-    upVotes: number,
-    downVotes: number,
+    type: string,
+    upVotes?: number,
+    downVotes?: number,
     avgConfidence: string
 }
 


### PR DESCRIPTION
* Use different CSS classes for different types of blacklisted accounts, and vary opacity to relate to confidence value.
* Start parsing engagement activity for detection
* Add Detection to page level context menu

Addresses:
#31  